### PR TITLE
Changed initializer lists of tuples to uniform initializations in additional_cell_data tests

### DIFF
--- a/tests/additional_cell_data/neighbor_data1.cpp
+++ b/tests/additional_cell_data/neighbor_data1.cpp
@@ -44,7 +44,7 @@ struct Additional_Neighbor_Data_Item1 {
 };
 
 struct Additional_Neighbor_Data_Item2 {
-	std::tuple<int, float> additional_neighbor_data3 = {2, 3.0625};
+	std::tuple<int, float> additional_neighbor_data3 {2, 3.0625};
 	unsigned int additional_neighbor_data4 = 4;
 	template<class Grid, class Cell_Item, class Neighbor_Item> void update(const Grid&, const Cell_Item&, const Neighbor_Item&, const Additional_Neighbor_Data_Item2&) {}
 };

--- a/tests/additional_cell_data/test1.cpp
+++ b/tests/additional_cell_data/test1.cpp
@@ -43,7 +43,7 @@ struct Additional_Cell_Data_Item1 {
 };
 
 struct Additional_Cell_Data_Item2 {
-	std::tuple<int, float> additional_cell_data3 = {2, 3.0625};
+	std::tuple<int, float> additional_cell_data3 {2, 3.0625};
 	unsigned int additional_cell_data4 = 4;
 	template<class Grid, class Cell> void update(const Grid&, const Cell&, const Additional_Cell_Data_Item2&) {}
 };


### PR DESCRIPTION
Changed initializer lists of tuples to uniform initializations, according to the answer here https://stackoverflow.com/questions/3413050/initializing-stdtuple-from-initializer-list . This was necessary to compile on gcc 5.4.0.