### PR TITLE
Split stop_refining()

### DIFF
--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -3218,7 +3218,6 @@ public:
 			abort();
 		}
 
-		// No check whether start_refining() has been called...
 		this->start_user_data_transfers(
 			this->unrefined_cell_data,
 			this->cells_to_receive,
@@ -3297,7 +3296,6 @@ public:
 			std::cerr << __FILE__ << ":" << __LINE__
 				<< " stop_refining() called with unrefined cells. "
 				<< std::endl;
-			abort();
 		}
 		this->finish_refining();
 		return ret_val;


### PR DESCRIPTION
Splits the function `stop_refining()` so unrefined cells can transfer data multiple times, the same way as `balance_load()` works.

Retains compatibility with old interface, `stop_refining()` now calls `start_refining()`, `continue_refining()` and `finish_refining()`.