### PR TITLE
Patch for undefined behaviour (nullpointer reference).

### DIFF
--- a/dccrg_mpi_support.hpp
+++ b/dccrg_mpi_support.hpp
@@ -185,6 +185,10 @@ public:
 			total_send_count += (uint64_t) send_count;
 		}
 
+		if(total_send_count == 0) {
+			//Early abort if there is nothing to communicate.
+			return;
+		}
 		std::vector<uint64_t> temp_result(total_send_count, std::numeric_limits<uint64_t>::max());
 
 		// give a sane address to gatherv also when nothing to send


### PR DESCRIPTION
For communication of empty (zero velocity blocks) Vlasiator cells, this was trying to do an AllGather of some empty arrays, but the actual Allgatherv call tried to acess ```&(temp_result[0])```, which is technically a nullpointer dereference.

This probably wasn't causing any actual issue (because every sane compiler would optimize that away anyway), but was reported by GCC12's undefined behaviour sanitizer.

But anyway, if total_send_count is zero in the AllGather, the whole second stage of the communication can anyway be skipped, so that's how this is fixed now.