### PR TITLE
Face neighbor caching fix

### DIFF
--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -3679,6 +3679,8 @@ public:
 		}
 
 		// update data for parents (and their neighborhood) of unrefined cells
+		// TODO: this loop happens to casually bypass the update_neighbors function
+		// It gave me a headache and will give one to you too, see if this can be refactored
 		for (const uint64_t parent: parents_of_unrefined) {
 
 			/* TODO: skip unrefined cells far enough away
@@ -3732,6 +3734,7 @@ public:
 				this->cell_data[parent];
 				this->neighbors_of[parent] = new_neighbors_of;
 				this->neighbors_to[parent] = new_neighbors_to;
+				this->face_neighbors_of[parent] = this->find_face_neighbors_of(parent);
 
 				// add user neighbor lists
 				for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -3782,6 +3782,7 @@ public:
 
 				this->neighbors_of.erase(refined);
 				this->neighbors_to.erase(refined);
+				this->face_neighbors_of.erase(refined);
 
 				// remove also from user's neighborhood
 				for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -3799,6 +3800,7 @@ public:
 		for (const uint64_t unrefined: this->all_to_unrefine) {
 			this->neighbors_of.erase(unrefined);
 			this->neighbors_to.erase(unrefined);
+			this->face_neighbors_of.erase(unrefined);
 			// also from user neighborhood
 			for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
 				item = this->user_hood_of.begin();
@@ -4527,6 +4529,7 @@ public:
 			this->cell_data.erase(removed_cell);
 			this->neighbors_of.erase(removed_cell);
 			this->neighbors_to.erase(removed_cell);
+			this->face_neighbors_of.erase(removed_cell);
 
 			// also user neighbor lists
 			for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -9747,7 +9747,7 @@ private:
 					this->neighborhood_of,
 					2 * this->max_ref_lvl_diff,
 					true
-				);	// todo PRETTY SURE THIS SHOULDN'T BE HERE!
+				);	// todo this should probably be using cached values
 
 			for (const auto& neighbor_i: neighbors) {
 				const auto& neighbor = neighbor_i.first;


### PR DESCRIPTION
- Revert #34, restoring #24 
- Erase cached face neighbors whenever other neighborhoods are erased
- Update cached face neighbors properly for unrefined cells