### PR TITLE
Revert "Cache face neighbors"

### DIFF
--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -2618,13 +2618,6 @@ public:
 		return true;
 	}
 
-	const std::vector<std::pair<uint64_t, int>>& get_face_neighbors_of (const uint64_t cell) const
-	{
-		// Could add checks or return a nullptr / empty vector / whatever
-		// But honestly it's just better to throw
-		return face_neighbors_of.at(cell);
-	}
-
 	/*!
 	Returns cells which share a face with the given cell.
 
@@ -2645,7 +2638,7 @@ public:
 	default_neighborhood_id()
 	get_neighbors_of()
 	*/
-	std::vector<std::pair<uint64_t, int> > find_face_neighbors_of(
+	std::vector<std::pair<uint64_t, int> > get_face_neighbors_of(
 		const uint64_t cell/*,
 		const int neighborhood_id = default_neighborhood_id*/
 	) const {
@@ -4510,7 +4503,11 @@ public:
 				continue;
 			}
 
-			this->update_neighbors(added_cell);
+			// TODO: use this->update_neighbors(added_cell)
+			this->neighbors_of[added_cell]
+				= this->find_neighbors_of(added_cell, this->neighborhood_of, this->max_ref_lvl_diff);
+			this->neighbors_to[added_cell]
+				= this->find_neighbors_to(added_cell, this->neighborhood_to);
 
 			// also update user neighbor lists
 			for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -7322,9 +7319,6 @@ private:
 		>
 	> neighbors_of;
 
-	// Cached face neighbors on this process
-	std::unordered_map<uint64_t, std::vector<std::pair<uint64_t, int>>> face_neighbors_of;
-
 	/*
 	Offsets of cells that are considered as neighbors of a cell and
 	offsets of cells that consider a cell as a neighbor
@@ -8283,7 +8277,8 @@ private:
 	{
 		// update neighbor lists of created cells
 		for (const auto& item: this->cell_data) {
-			this->neighbors_of[item.first] = this->find_neighbors_of(item.first, this->neighborhood_of, this->max_ref_lvl_diff);
+			this->neighbors_of[item.first]
+				= this->find_neighbors_of(item.first, this->neighborhood_of, this->max_ref_lvl_diff);
 			#ifdef DEBUG
 			for (const auto& neighbor: this->neighbors_of.at(item.first)) {
 				if (neighbor.first == error_cell) {
@@ -8302,8 +8297,8 @@ private:
 			}
 			#endif
 
-			this->neighbors_to[item.first] = this->find_neighbors_to(item.first, this->neighborhood_to);
-			this->face_neighbors_of[item.first] = this->find_face_neighbors_of(item.first);
+			this->neighbors_to[item.first]
+				= this->find_neighbors_to(item.first, this->neighborhood_to);
 		}
 		#ifdef DEBUG
 		if (!this->verify_neighbors()) {
@@ -8953,14 +8948,12 @@ private:
 			return;
 		}
 
-		this->neighbors_of[cell] = this->find_neighbors_of(cell, this->neighborhood_of, this->max_ref_lvl_diff);
+		this->neighbors_of.at(cell) = this->find_neighbors_of(cell, this->neighborhood_of, this->max_ref_lvl_diff);
 		std::vector<uint64_t> found_neighbors_of;
-		for (const auto& i: this->neighbors_of[cell]) {
+		for (const auto& i: this->neighbors_of.at(cell)) {
 			found_neighbors_of.push_back(i.first);
 		}
-		this->neighbors_to[cell] = this->find_neighbors_to(cell, found_neighbors_of);
-
-		this->face_neighbors_of[cell] = this->find_face_neighbors_of(cell);
+		this->neighbors_to.at(cell) = this->find_neighbors_to(cell, found_neighbors_of);
 
 		#ifdef DEBUG
 		if (
@@ -9729,7 +9722,7 @@ private:
 					this->neighborhood_of,
 					2 * this->max_ref_lvl_diff,
 					true
-				);	// todo PRETTY SURE THIS SHOULDN'T BE HERE!
+				);
 
 			for (const auto& neighbor_i: neighbors) {
 				const auto& neighbor = neighbor_i.first;


### PR DESCRIPTION
Reverts face neighbor caching due to pending issues with dccrg returning bad cell pointers.