### PR TITLE
Added return function also for remote cells editing

### DIFF
--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -6943,6 +6943,13 @@ public:
 	{
 		return this->cell_data;
 	}
+	/*!
+	Returns the storage of remote cell ids and their data. Warning, non-const return value!
+	*/
+        std::unordered_map<uint64_t, Cell_Data>& get_remote_cell_data_for_editing()
+	{
+		return this->remote_neighbors;
+	}
 
 	/*!
 	Returns the neighborhood of cells.


### PR DESCRIPTION
Same as the previous function, but this one returns remote cells. This is needed for clean exit in Vlasiator's GPU branch when running on several MPI tasks.