### PR TITLE
Fix memory spikes

### DIFF
--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -9583,6 +9583,12 @@ private:
 			unique_induced_refines.clear();
 		}
 
+		for(const auto& cell : this->cells_to_refine) {
+			if(!this->is_local(cell)) {
+				this->cells_to_refine.erase(cell);
+			}
+		}
+
 		// add refines from all processes to cells_to_refine
 		std::vector<uint64_t> refines(this->cells_to_refine.begin(), this->cells_to_refine.end());
 		std::vector<std::vector<uint64_t>> all_refines;
@@ -9659,7 +9665,7 @@ private:
 		All_Gather()(local_s, all_s, this->comm);
 
 		for (const auto& i: all_s) {
-			for (const uint64_t cell: i) {
+			for (const uint64_t& cell: i) {
 				s.insert(cell);
 			}
 		}
@@ -9747,6 +9753,12 @@ private:
 		}
 		this->cells_to_unrefine.clear();
 		this->cells_not_to_unrefine.clear();
+
+		for(const auto& cell : final_unrefines) {
+			if(!this->is_local(cell)) {
+				final_unrefines.erase(cell);
+			}
+		}
 
 		// add unrefines from all processes to cells_to_unrefine
 		std::vector<uint64_t> unrefines(final_unrefines.begin(), final_unrefines.end());
@@ -9890,6 +9902,12 @@ private:
 
 			this->all_to_all_set(new_donts);
 		} while (new_donts.size() > 0);
+
+		for (const auto& cell : old_donts) {
+			if(!this->is_local(cell)) {
+				old_donts.erase(cell);
+			}
+		}
 
 		this->cells_not_to_refine = old_donts;
 		this->all_to_all_set(this->cells_not_to_refine);


### PR DESCRIPTION
Some refinement functions ended up communicating all cells to all tasks, yielding huge spikes in memory high-water mark. This fixes some of it.

Going to test at production scale on LUMI-C.