### PR TITLE
Change neighbor definition to "n unique cells in this direction"

### DIFF
--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8912,10 +8912,18 @@ private:
 		for(int dimension=0; dimension <3; dimension++) {
 
 			// If indices1[dim] == indices2[dim], we do not need to step in this direction at all
-			// (More precisely, if this dimension is already inside the bounds of the target cell)
+			// More precisely, if this dimension is already inside the bounds of the target cell.
 			//   => Zero ranges
 			if(indices1[dimension] >= indices2[dimension] && indices1[dimension] < indices2[dimension] + cell2_size) {
 				step_ranges[dimension].push_back(0);
+				step_dir[dimension].push_back(0);
+				continue;
+			}
+
+			// Oppositely, this cell's bounds encompass the target cell.
+			if(indices2[dimension] >= indices1[dimension] && indices2[dimension] < indices1[dimension] + cell1_size) {
+				// We mark the required path offset by setting a step range, but leaving direction at zero.
+				step_ranges[dimension].push_back(indices2[dimension]-indices1[dimension]);
 				step_dir[dimension].push_back(0);
 				continue;
 			}
@@ -8975,7 +8983,9 @@ private:
 					for(int dim = 0; dim < 3; dim++) {
 						if(dir[dim] > 0) {
 							x[dim] += cell1_size -1;
-						} 
+						} else if(dir[dim] == 0) {
+							x[dim] += steps[dim];
+						}
 					}
 
 					std::array<int,3> cells_seen = {0,0,0};

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -3202,7 +3202,7 @@ public:
 		std::vector<std::vector<uint64_t>> all_ordered_cells_to_unrefine;
 		All_Gather()(ordered_cells_to_unrefine, all_ordered_cells_to_unrefine, this->comm);
 
-		for (unsigned int process = 0; process < this->comm_size; process++) {
+		for (unsigned int process = 0; process < all_ordered_cells_to_unrefine.size(); process++) {
 			if (!std::equal(
 				all_ordered_cells_to_unrefine[process].begin(),
 				all_ordered_cells_to_unrefine[process].end(),
@@ -4600,6 +4600,7 @@ public:
 					other_path_x[dim1] = x[dim1];
 					retval.merge(find_cells_at_offset(other_path_x, last_cell_seen, refinement_level+1, other_path_offset, dims));
 					// The fourth path will continue here as before.
+					refinement_level++;
 				}
 			}
 		}
@@ -11682,7 +11683,7 @@ private:
 	*/
 	bool verify_user_data()
 	{
-      for (const auto& item : this->cell_process) {
+		for (const auto& item : this->cell_process) {
 			if (item.second == this->rank
 			&& item.first == this->get_child(item.first)
 			&& this->cell_data.count(item.first) == 0) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8775,11 +8775,11 @@ private:
 		}
 		#endif
 
+		this->user_neigh_of[neighborhood_id][cell].clear();
+		this->user_neigh_to[neighborhood_id][cell].clear();
 		if (this->cell_data.count(cell) == 0) {
 			return;
 		}
-		this->user_neigh_of[neighborhood_id][cell].clear();
-		this->user_neigh_to[neighborhood_id][cell].clear();
 		if (cell != this->get_child(cell)) {
 			return;
 		}

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8786,7 +8786,7 @@ private:
 		if (!this->verify_remote_neighbor_info(cell)) {
 			std::cerr << __FILE__ << ":" << __LINE__
 				<< " Remote neighbor info for cell " << cell
-				<< " is not consistent"
+				<< " is not consistent on rank " << this->rank
 				<< std::endl;
 			abort();
 		}
@@ -8946,7 +8946,7 @@ private:
 			if (!this->verify_remote_neighbor_info(item.first)) {
 				std::cerr << __FILE__ << ":" << __LINE__
 					<< " Remote neighbor info for cell " << item.first
-					<< " is not consistent"
+					<< " is not consistent on rank " << this->rank
 					<< std::endl;
 				abort();
 			}
@@ -8956,7 +8956,7 @@ private:
 		#ifdef DEBUG
 		if (!this->verify_remote_neighbor_info()) {
 			std::cerr << __FILE__ << ":" << __LINE__
-				<< " Remote neighbor info is not consistent"
+				<< " Remote neighbor info is not consistent on rank " << this->rank
 				<< std::endl;
 			abort();
 		}

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4514,7 +4514,7 @@ public:
 		// Walk in the same dimensional order as Vlasiator's translation solver.
 		// (https://github.com/fmihpc/vlasiator/blob/master/vlasovsolver/vlasovmover.cpp#L66)
 		for(int dimension : dims) {
-			while(cells_seen[dimension] < abs(offsets[dimension])) {
+			while(cells_seen[dimension] < abs(offsets[dimension]) && last_cell_seen != error_cell) {
 
 				// We can stop stepping if this cell spans the whole domain in this direction
 				if(refinement_level == 0 && grid_length[dimension] == (int64_t(1) << this->mapping.get_maximum_refinement_level()) ) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -3279,22 +3279,24 @@ public:
 				No need to update local neighbors_to of refined cell, if they are larger
 				they will also be refined and updated.
 				*/
-				const auto neighbors
-					= this->find_neighbors_of(
-						refined,
-						this->neighborhood_of,
-						true
-					);
+				for(const auto& child : children) {
+					const auto neighbors
+						= this->find_neighbors_of(
+							child,
+							this->neighborhood_of,
+							true
+						);
 
-				for (const auto& neighbor_i: neighbors) {
-					const auto& neighbor = neighbor_i.first;
+					for (const auto& neighbor_i: neighbors) {
+						const auto& neighbor = neighbor_i.first;
 
-					if (neighbor == error_cell) {
-						continue;
-					}
+						if (neighbor == error_cell) {
+							continue;
+						}
 
-					if (this->is_local(neighbor)) {
-						update_neighbors.insert(neighbor);
+						if (this->is_local(neighbor)) {
+							update_neighbors.insert(neighbor);
+						}
 					}
 				}
 			}

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8540,7 +8540,7 @@ private:
 			}
 			#endif
 
-			// data must be received from neighbors_of
+			// data must be sent/received to/from neighbors_of
 			for (const auto& neighbor_i: this->user_neigh_of.at(neighborhood_id).at(cell)) {
 				const auto& neighbor = neighbor_i.first;
 
@@ -8550,10 +8550,11 @@ private:
 
 				if (this->cell_process.at(neighbor) != this->rank) {
 					user_neigh_unique_receives[int(this->cell_process.at(neighbor))].insert(neighbor);
+					user_neigh_unique_sends[int(this->cell_process.at(neighbor))].insert(cell);
 				}
 			}
 
-			// data must be sent to neighbors_to
+			// data must be sent/received to/from neighbors_to
 			for (const auto& neighbor_i: this->user_neigh_to.at(neighborhood_id).at(cell)) {
 				const auto& neighbor = neighbor_i.first;
 
@@ -8562,6 +8563,7 @@ private:
 				}
 
 				if (this->cell_process.at(neighbor) != this->rank) {
+					user_neigh_unique_receives[int(this->cell_process.at(neighbor))].insert(neighbor);
 					user_neigh_unique_sends[int(this->cell_process.at(neighbor))].insert(cell);
 				}
 			}

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4498,12 +4498,12 @@ public:
 
       // grid length in indices
       const int64_t grid_length[3] = {
-         this->length.get()[0] * (int64_t(1) << this->mapping.get_maximum_refinement_level()),
-         this->length.get()[1] * (int64_t(1) << this->mapping.get_maximum_refinement_level()),
-         this->length.get()[2] * (int64_t(1) << this->mapping.get_maximum_refinement_level())
+         (int64_t)this->length.get()[0] * (int64_t(1) << this->mapping.get_maximum_refinement_level()),
+         (int64_t)this->length.get()[1] * (int64_t(1) << this->mapping.get_maximum_refinement_level()),
+         (int64_t)this->length.get()[2] * (int64_t(1) << this->mapping.get_maximum_refinement_level())
       };
 
-      std::array<int,3>  x = {starting_point[0],starting_point[1],starting_point[2]};
+      std::array<int,3>  x = {(int)starting_point[0],(int)starting_point[1],(int)starting_point[2]};
       std::array<int,3> cells_seen = {0,0,0};
       uint64_t last_cell_seen = starting_cell;
 
@@ -4550,7 +4550,10 @@ public:
                }
             }
 
-            uint64_t cellHere = this->get_existing_cell({x[0],x[1],x[2]},std::max(refinement_level-1,0), std::min(refinement_level+1, this->mapping.get_maximum_refinement_level()));
+            uint64_t cellHere = this->get_existing_cell(
+                  {(uint64_t)x[0],(uint64_t)x[1],(uint64_t)x[2]},
+                  std::max(refinement_level-1,0), 
+                  std::min(refinement_level+1, this->mapping.get_maximum_refinement_level()));
             // Continue stepping if still inside the same cell as before.
             if(cellHere == last_cell_seen) {
                continue;
@@ -4579,7 +4582,7 @@ public:
                   other_path_offset[i] -= cells_seen[i];
                }
 
-               Types<3>::indices_t other_path_x = {x[0], x[1], x[2]};
+               Types<3>::indices_t other_path_x = {(uint64_t)x[0], (uint64_t)x[1], (uint64_t)x[2]};
 
                // TODO: This can be optimized in the corners.
                // Find at offset (1,0)

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4622,6 +4622,8 @@ public:
 						std::max(refinement_level-2,0), 
 						std::min(refinement_level+1, this->mapping.get_maximum_refinement_level()));
 
+				int effective_refinement_level = this->mapping.get_refinement_level(cellHere);
+
 				// Apparently, this is a new cell.
 				if(cellHere != last_cell_seen) {
 
@@ -4636,7 +4638,6 @@ public:
 					// OR
 					// - Add 1 if we determine that it is too coarse for our
 					// starting cell's new refinement state.
-					int effective_refinement_level= this->mapping.get_refinement_level(cellHere);
 					if(find(new_refines.begin(), new_refines.end(), cellHere) != new_refines.end()) {
 						effective_refinement_level++;
 
@@ -4673,7 +4674,7 @@ public:
 				}
 
 				// We can stop stepping if this cell spans the whole domain in this direction
-				if(refinement_level == 0 && grid_length[dimension] == (int64_t(1) << this->mapping.get_maximum_refinement_level()) ) {
+				if(effective_refinement_level == 0 && grid_length[dimension] == (int64_t(1) << this->mapping.get_maximum_refinement_level()) ) {
 					cells_seen[dimension]=abs(offsets[dimension]);
 					break;
 				}

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4900,7 +4900,7 @@ public:
 
 			for (const auto& neighCell : neigh_cells) {
 				if (neighCell == error_cell) {
-					return_neighbors.push_back({0, {0, 0, 0, 0}});
+					//return_neighbors.push_back({0, {0, 0, 0, 0}});
 					continue;
 				}
 
@@ -4994,7 +4994,7 @@ public:
 
 			for (const auto& neighCell : neigh_cells) {
 				if (neighCell == error_cell) {
-					return_neighbors.push_back({0, {0, 0, 0, 0}});
+					//return_neighbors.push_back({0, {0, 0, 0, 0}});
 					continue;
 				}
 

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -2644,7 +2644,7 @@ public:
 	) const {
 		std::vector<std::pair<uint64_t, int> > ret_val;
 
-		if (this->cell_process.count(cell) > 0) {
+		if (this->cell_process.count(cell) == 0) {
 			return ret_val;
 		}
 
@@ -8700,6 +8700,8 @@ private:
 		// if (this->cell_process.at(cell) != this->rank) {
 		// 	return;
 		// }
+		this->neighbors_of[cell].clear();
+		this->neighbors_to[cell].clear();
 
 		if (cell != this->get_child(cell)) {
 			return;
@@ -8772,6 +8774,15 @@ private:
 			abort();
 		}
 		#endif
+
+		if (this->cell_process.count(cell) == 0) {
+			return;
+		}
+		this->user_neigh_of[neighborhood_id][cell].clear();
+		this->user_neigh_to[neighborhood_id][cell].clear();
+		if (cell != this->get_child(cell)) {
+			return;
+		}
 
 		// find neighbors_of, should be in order given by user
 		this->user_neigh_of[neighborhood_id][cell]

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4432,9 +4432,9 @@ public:
 	  Find the cell (or, potentially, multiple cells) that can be encountered by hopping
 	  from face neighbour to face neighbour along the given offset path.
 	  The "offset" parameter defines how many unique cells should be traveled in each dimension.
-	"dims" defines the order in which dimensions are stepped through. For proper
-	matching of neighbors_to and neighbors_of, these should be constructed in
-	opposite direction.
+	  "dims" defines the order in which dimensions are stepped through.For proper
+	  matching of neighbors_to and neighbors_of, these should be constructed in
+	  opposite direction.
 	*/
 	std::set<uint64_t> find_cells_at_offset(
 			const Types<3>::indices_t starting_point,
@@ -4523,6 +4523,7 @@ public:
 					steps_inside_this_cell++;
 					if(steps_inside_this_cell > (int64_t(1) << this->mapping.get_maximum_refinement_level())) {
 						// Apparently, we are trapped in a periodic loop.
+						last_cell_seen = error_cell;
 						break;
 					}
 				}
@@ -8553,7 +8554,7 @@ private:
 			}
 			#endif
 
-			// data must be sent/received to/from neighbors_of
+			// data must be sent to neighbors_of
 			for (const auto& neighbor_i: this->user_neigh_of.at(neighborhood_id).at(cell)) {
 				const auto& neighbor = neighbor_i.first;
 
@@ -8563,11 +8564,11 @@ private:
 
 				if (this->cell_process.at(neighbor) != this->rank) {
 					user_neigh_unique_receives[int(this->cell_process.at(neighbor))].insert(neighbor);
-					user_neigh_unique_sends[int(this->cell_process.at(neighbor))].insert(cell);
+					//user_neigh_unique_sends[int(this->cell_process.at(neighbor))].insert(cell);
 				}
 			}
 
-			// data must be sent/received to/from neighbors_to
+			// data must be received from neighbors_to
 			for (const auto& neighbor_i: this->user_neigh_to.at(neighborhood_id).at(cell)) {
 				const auto& neighbor = neighbor_i.first;
 
@@ -8576,7 +8577,7 @@ private:
 				}
 
 				if (this->cell_process.at(neighbor) != this->rank) {
-					user_neigh_unique_receives[int(this->cell_process.at(neighbor))].insert(neighbor);
+					//user_neigh_unique_receives[int(this->cell_process.at(neighbor))].insert(neighbor);
 					user_neigh_unique_sends[int(this->cell_process.at(neighbor))].insert(cell);
 				}
 			}

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4506,11 +4506,11 @@ public:
 		std::array<int,3>  x = {(int)starting_point[0],(int)starting_point[1],(int)starting_point[2]};
 		std::array<int,3> cells_seen = {0,0,0};
 		uint64_t last_cell_seen = starting_cell;
-		int steps_inside_this_cell = 0;
 
 		// Walk in the same dimensional order as Vlasiator's translation solver.
 		// (https://github.com/fmihpc/vlasiator/blob/master/vlasovsolver/vlasovmover.cpp#L66)
 		for(int dimension : dims) {
+			int steps_inside_this_cell = 0;
 
 			while(cells_seen[dimension] <= abs(offsets[dimension]) && last_cell_seen != error_cell) {
 
@@ -4544,10 +4544,10 @@ public:
 						}
 
 						// The other paths start such that they are quantized to the refinement level edges
-						Types<3>::indices_t other_path_x = {(uint64_t)x[0], (uint64_t)x[1], (uint64_t)x[2]};
 						for(int i : {dim1,dim2}) {
 							x[i] -= x[i] % (1<<(this->mapping.get_maximum_refinement_level() - refinement_level));
 						}
+						Types<3>::indices_t other_path_x = {(uint64_t)x[0], (uint64_t)x[1], (uint64_t)x[2]};
 
 						// Find at offset (1,0)
 						other_path_x[dim1] += (1<<(this->mapping.get_maximum_refinement_level() - (refinement_level+1)));

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -2607,13 +2607,6 @@ public:
 		return true;
 	}
 
-	const std::vector<std::pair<uint64_t, int>>& get_face_neighbors_of (const uint64_t cell) const
-	{
-		// Could add checks or return a nullptr / empty vector / whatever
-		// But honestly it's just better to throw
-		return face_neighbors_of.at(cell);
-	}
-
 	/*!
 	Returns cells which share a face with the given cell.
 
@@ -3548,7 +3541,6 @@ public:
 				this->cell_data[parent];
 				this->neighbors_of[parent] = new_neighbors_of;
 				this->neighbors_to[parent] = new_neighbors_to;
-				this->face_neighbors_of[parent] = this->find_face_neighbors_of(parent);
 
 				// add user neighbor lists
 				for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -3599,7 +3591,6 @@ public:
 
 				this->neighbors_of.erase(refined);
 				this->neighbors_to.erase(refined);
-				this->face_neighbors_of.erase(refined);
 
 				// remove also from user's neighborhood
 				for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -3617,7 +3608,6 @@ public:
 		for (const uint64_t unrefined: this->all_to_unrefine) {
 			this->neighbors_of.erase(unrefined);
 			this->neighbors_to.erase(unrefined);
-			this->face_neighbors_of.erase(unrefined);
 			// also from user neighborhood
 			for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
 				item = this->user_hood_of.begin();
@@ -4342,7 +4332,6 @@ public:
 			this->cell_data.erase(removed_cell);
 			this->neighbors_of.erase(removed_cell);
 			this->neighbors_to.erase(removed_cell);
-			this->face_neighbors_of.erase(removed_cell);
 
 			// also user neighbor lists
 			for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -7042,9 +7031,6 @@ private:
 		>
 	> neighbors_of;
 
-	// Cached face neighbors on this process
-	std::unordered_map<uint64_t, std::vector<std::pair<uint64_t, int>>> face_neighbors_of;
-
 	/*
 	Offsets of cells that are considered as neighbors of a cell and
 	offsets of cells that consider a cell as a neighbor
@@ -8035,7 +8021,6 @@ private:
 			#endif
 
 			this->neighbors_to[item.first] = this->find_neighbors_to(item.first, this->neighborhood_to);
-			this->face_neighbors_of[item.first] = this->find_face_neighbors_of(item.first);
 		}
 		#ifdef DEBUG
 		if (!this->verify_neighbors()) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -772,7 +772,7 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_data.count(cell) > 0) {
+		if (this->cell_process.count(cell) > 0) {
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
 				if (this->neighbors_of.count(cell) == 0) {
@@ -826,8 +826,7 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_data.count(cell) > 0) {
-
+		if (this->cell_process.count(cell) > 0) {
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
 				if (this->neighbors_to.count(cell) == 0) {
@@ -2644,7 +2643,7 @@ public:
 	) const {
 		std::vector<std::pair<uint64_t, int> > ret_val;
 
-		if (this->cell_data.count(cell) == 0) {
+		if (this->cell_process.count(cell) == 0) {
 			return ret_val;
 		}
 
@@ -8777,7 +8776,7 @@ private:
 
 		this->user_neigh_of[neighborhood_id][cell].clear();
 		this->user_neigh_to[neighborhood_id][cell].clear();
-		if (this->cell_data.count(cell) == 0) {
+		if (this->cell_process.count(cell) == 0) {
 			return;
 		}
 		if (cell != this->get_child(cell)) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -2611,6 +2611,13 @@ public:
 		return true;
 	}
 
+	const std::vector<std::pair<uint64_t, int>>& get_face_neighbors_of (const uint64_t cell) const
+	{
+		// Could add checks or return a nullptr / empty vector / whatever
+		// But honestly it's just better to throw
+		return face_neighbors_of.at(cell);
+	}
+
 	/*!
 	Returns cells which share a face with the given cell.
 
@@ -3545,6 +3552,7 @@ public:
 				this->cell_data[parent];
 				this->neighbors_of[parent] = new_neighbors_of;
 				this->neighbors_to[parent] = new_neighbors_to;
+				this->face_neighbors_of[parent] = this->find_face_neighbors_of(parent);
 
 				// add user neighbor lists
 				for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -3595,6 +3603,7 @@ public:
 
 				this->neighbors_of.erase(refined);
 				this->neighbors_to.erase(refined);
+				this->face_neighbors_of.erase(refined);
 
 				// remove also from user's neighborhood
 				for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -3612,6 +3621,7 @@ public:
 		for (const uint64_t unrefined: this->all_to_unrefine) {
 			this->neighbors_of.erase(unrefined);
 			this->neighbors_to.erase(unrefined);
+			this->face_neighbors_of.erase(unrefined);
 			// also from user neighborhood
 			for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
 				item = this->user_hood_of.begin();
@@ -4336,6 +4346,7 @@ public:
 			this->cell_data.erase(removed_cell);
 			this->neighbors_of.erase(removed_cell);
 			this->neighbors_to.erase(removed_cell);
+			this->face_neighbors_of.erase(removed_cell);
 
 			// also user neighbor lists
 			for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
@@ -7043,6 +7054,9 @@ private:
 		>
 	> neighbors_of;
 
+	// Cached face neighbors on this process
+	std::unordered_map<uint64_t, std::vector<std::pair<uint64_t, int>>> face_neighbors_of;
+
 	/*
 	Offsets of cells that are considered as neighbors of a cell and
 	offsets of cells that consider a cell as a neighbor
@@ -8033,6 +8047,7 @@ private:
 			#endif
 
 			this->neighbors_to[item.first] = this->find_neighbors_to(item.first, this->neighborhood_to);
+			this->face_neighbors_of[item.first] = this->find_face_neighbors_of(item.first);
 		}
 		#ifdef DEBUG
 		if (!this->verify_neighbors()) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -2639,37 +2639,37 @@ public:
 		}
 
 
-      // Iterate through neighbours and only return those with a single 1
-      // index.
-      for(const auto& neigh : this->neighbors_of.at(cell)) {
-         uint64_t nbrID = neigh.first;
-         auto offsets = neigh.second;
+		// Iterate through neighbours and only return those with a single 1
+		// index.
+		for(const auto& neigh : this->neighbors_of.at(cell)) {
+			uint64_t nbrID = neigh.first;
+			auto offsets = neigh.second;
 
-         if(nbrID == error_cell) {
-            continue;
-         }
+			if(nbrID == error_cell) {
+				continue;
+			}
 
-         // We want all the neighbours with an offset sum of 1.
-         int offsetsum=0;
-         for (size_t dimension = 0; dimension < 3; dimension++) {
-            offsetsum+=abs(offsets[dimension]);
-         }
-         if(offsetsum == 0 || offsetsum > 1) {
-            continue;
-         }
+			// We want all the neighbours with an offset sum of 1.
+			int offsetsum=0;
+			for (size_t dimension = 0; dimension < 3; dimension++) {
+				offsetsum+=abs(offsets[dimension]);
+			}
+			if(offsetsum == 0 || offsetsum > 1) {
+				continue;
+			}
 
-         // Find the dimension this is a neighbour in
-         for (size_t dimension = 0; dimension < 3; dimension++) {
-            if(abs(offsets[dimension]) == 1) {
-               int final_dir = int(dimension) + 1;
-               if(offsets[dimension] < 0) {
-                  final_dir *= -1;
-               }
+			// Find the dimension this is a neighbour in
+			for (size_t dimension = 0; dimension < 3; dimension++) {
+				if(abs(offsets[dimension]) == 1) {
+					int final_dir = int(dimension) + 1;
+					if(offsets[dimension] < 0) {
+						final_dir *= -1;
+					}
 
-               ret_val.push_back({nbrID, final_dir});
-            }
-         }
-      }
+					ret_val.push_back({nbrID, final_dir});
+				}
+			}
+		}
 
 		return ret_val;
 	}

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8865,7 +8865,7 @@ private:
 
 
 	/*!
-	Returns true if cell1 considers cell2 as a neighbor, even if neither of them exists
+	Returns true if cell1 considers cell2 as a neighbor, even
 	*/
 	bool is_neighbor(const uint64_t cell1, const uint64_t cell2, const std::array<int,3> dims = {2,0,1}) const
 	{
@@ -9000,12 +9000,12 @@ private:
 							}
 							last_cell_seen = cellHere;
 
-							if(cells_seen[dimension] >= (int)this->neighborhood_length) {
+							if(steps[dimension] == 0) {
 								break;
 							}
 
-							if(steps[dimension] == 0) {
-								break;
+							if(cells_seen[dimension] > (int)this->neighborhood_length) {
+								goto next_path;
 							}
 
 							// note we don't need to do any refinement path splitting here

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8999,16 +8999,22 @@ private:
 									std::max(refinement_level-1,0), 
 									std::min(refinement_level+1, this->mapping.get_maximum_refinement_level()));
 
-							if(cellHere == cell2) {
-								return true;
-							}
-
 							// Apparently, this is a new cell.
 							if(cellHere != last_cell_seen) {
 								// Count how many unique cells were encountered.
 								cells_seen[dimension]++;
 							}
 							last_cell_seen = cellHere;
+
+							if(cellHere == cell2) {
+								if(cells_seen[0] > (int)this->neighborhood_length ||
+								   cells_seen[1] > (int)this->neighborhood_length ||
+								   cells_seen[2] > (int)this->neighborhood_length) {
+									goto next_path;
+								}
+								return true;
+							}
+
 
 							if(steps[dimension] == 0) {
 								break;

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4480,135 +4480,135 @@ public:
 		}
 	}
 
-   /*!
-   Find the cell (or, potentially, multiple cells) that can be encountered by hopping
-   from face neighbour to face neighbour along the given offset path.
-   The "offset" parameter defines how many unique cells should be traveled in each dimension.
+	/*!
+	  Find the cell (or, potentially, multiple cells) that can be encountered by hopping
+	  from face neighbour to face neighbour along the given offset path.
+	  The "offset" parameter defines how many unique cells should be traveled in each dimension.
 	"dims" defines the order in which dimensions are stepped through. For proper
 	matching of neighbors_to and neighbors_of, these should be constructed in
 	opposite direction.
-   */
-   std::set<uint64_t> find_cells_at_offset(
+	*/
+	std::set<uint64_t> find_cells_at_offset(
 			const Types<3>::indices_t starting_point,
-         uint64_t starting_cell,
-         int refinement_level,
-         const Types<3>::neighborhood_item_t& offsets, std::array<int, 3> dims = {2,0,1}) const {
+			uint64_t starting_cell,
+			int refinement_level,
+			const Types<3>::neighborhood_item_t& offsets, std::array<int, 3> dims = {2,0,1}) const {
 
-      std::set<uint64_t> retval;
+		std::set<uint64_t> retval;
 
-      // grid length in fully-refined indices
-      const int64_t grid_length[3] = {
-         (int64_t)this->length.get()[0] * (int64_t(1) << this->mapping.get_maximum_refinement_level()),
-         (int64_t)this->length.get()[1] * (int64_t(1) << this->mapping.get_maximum_refinement_level()),
-         (int64_t)this->length.get()[2] * (int64_t(1) << this->mapping.get_maximum_refinement_level())
-      };
+		// grid length in fully-refined indices
+		const int64_t grid_length[3] = {
+			(int64_t)this->length.get()[0] * (int64_t(1) << this->mapping.get_maximum_refinement_level()),
+			(int64_t)this->length.get()[1] * (int64_t(1) << this->mapping.get_maximum_refinement_level()),
+			(int64_t)this->length.get()[2] * (int64_t(1) << this->mapping.get_maximum_refinement_level())
+		};
 
-      auto sign = [](int64_t i) -> int64_t{
-         return (0<i)-(i<0);
-      };
+		auto sign = [](int64_t i) -> int64_t{
+			return (0<i)-(i<0);
+		};
 
-      std::array<int,3>  x = {(int)starting_point[0],(int)starting_point[1],(int)starting_point[2]};
-      std::array<int,3> cells_seen = {0,0,0};
-      uint64_t last_cell_seen = starting_cell;
+		std::array<int,3>  x = {(int)starting_point[0],(int)starting_point[1],(int)starting_point[2]};
+		std::array<int,3> cells_seen = {0,0,0};
+		uint64_t last_cell_seen = starting_cell;
 
-      // Walk in the same dimensional order as Vlasiator's translation solver.
-      // (https://github.com/fmihpc/vlasiator/blob/master/vlasovsolver/vlasovmover.cpp#L66)
-      for(int dimension : dims) {
-         while(cells_seen[dimension] < abs(offsets[dimension])) {
+		// Walk in the same dimensional order as Vlasiator's translation solver.
+		// (https://github.com/fmihpc/vlasiator/blob/master/vlasovsolver/vlasovmover.cpp#L66)
+		for(int dimension : dims) {
+			while(cells_seen[dimension] < abs(offsets[dimension])) {
 
-            // We can stop stepping if this cell spans the whole domain in this direction
-            if(refinement_level == 0 && grid_length[dimension] == (int64_t(1) << this->mapping.get_maximum_refinement_level()) ) {
-               cells_seen[dimension]=abs(offsets[dimension]);
-               continue;
-            }
+				// We can stop stepping if this cell spans the whole domain in this direction
+				if(refinement_level == 0 && grid_length[dimension] == (int64_t(1) << this->mapping.get_maximum_refinement_level()) ) {
+					cells_seen[dimension]=abs(offsets[dimension]);
+					continue;
+				}
 
-            if(offsets[dimension] < 0) {
-               x[dimension]--;
+				if(offsets[dimension] < 0) {
+					x[dimension]--;
 
-               // Handle periodic boundaries
-               if (this->topology.is_periodic(dimension)) {
-                  if(x[dimension] < 0) {
-                     x[dimension] = grid_length[dimension] - 1;
-                  }
-               } else {
-                  // In nonperiodic boundaries, don't step out of the domain
-                  if(x[dimension] < 0) {
-                     last_cell_seen=error_cell;
-                     break;
-                  }
-               }
-            } else {
-               x[dimension]++;
+					// Handle periodic boundaries
+					if (this->topology.is_periodic(dimension)) {
+						if(x[dimension] < 0) {
+							x[dimension] = grid_length[dimension] - 1;
+						}
+					} else {
+						// In nonperiodic boundaries, don't step out of the domain
+						if(x[dimension] < 0) {
+							last_cell_seen=error_cell;
+							break;
+						}
+					}
+				} else {
+					x[dimension]++;
 
-               // Handle periodic boundaries
-               if (this->topology.is_periodic(dimension)) {
-                  if(x[dimension] >= grid_length[dimension]) {
-                     x[dimension] = 0;
-                  }
-               } else {
-                  // In nonperiodic boundaries, don't step out of the domain
-                  if(x[dimension] >= grid_length[dimension]) {
-                     last_cell_seen=error_cell;
-                     break;
-                  }
-               }
-            }
+					// Handle periodic boundaries
+					if (this->topology.is_periodic(dimension)) {
+						if(x[dimension] >= grid_length[dimension]) {
+							x[dimension] = 0;
+						}
+					} else {
+						// In nonperiodic boundaries, don't step out of the domain
+						if(x[dimension] >= grid_length[dimension]) {
+							last_cell_seen=error_cell;
+							break;
+						}
+					}
+				}
 
-            uint64_t cellHere = this->get_existing_cell(
-                  {(uint64_t)x[0],(uint64_t)x[1],(uint64_t)x[2]},
-                  std::max(refinement_level-1,0), 
-                  std::min(refinement_level+1, this->mapping.get_maximum_refinement_level()));
+				uint64_t cellHere = this->get_existing_cell(
+						{(uint64_t)x[0],(uint64_t)x[1],(uint64_t)x[2]},
+						std::max(refinement_level-1,0), 
+						std::min(refinement_level+1, this->mapping.get_maximum_refinement_level()));
 
-            // Continue stepping if still inside the same cell as before.
-            if(cellHere == last_cell_seen) {
-               continue;
-            }
+				// Continue stepping if still inside the same cell as before.
+				if(cellHere == last_cell_seen) {
+					continue;
+				}
 
-            // Apparently, this is a new cell.
-            // Count how many unique cells were encountered.
-            cells_seen[dimension]++;
-            last_cell_seen = cellHere;
+				// Apparently, this is a new cell.
+				// Count how many unique cells were encountered.
+				cells_seen[dimension]++;
+				last_cell_seen = cellHere;
 
-            // Break if something went wonky.
-            if(last_cell_seen == error_cell) {
-               break;
-            }
+				// Break if something went wonky.
+				if(last_cell_seen == error_cell) {
+					break;
+				}
 
-            // If this cell had a higher refinement, we need to continue multiple paths.
-            if(this->mapping.get_refinement_level(cellHere) > refinement_level) {
-               // We select two dimensions perpendicular to our current walking direction
-               // and splitting the path among them.
-               int dim1=(dimension+1)%3;
-               int dim2=(dimension+2)%3;
+				// If this cell had a higher refinement, we need to continue multiple paths.
+				if(this->mapping.get_refinement_level(cellHere) > refinement_level) {
+					// We select two dimensions perpendicular to our current walking direction
+					// and splitting the path among them.
+					int dim1=(dimension+1)%3;
+					int dim2=(dimension+2)%3;
 
-               // The remaining path to walk is shorter.
-               Types<3>::neighborhood_item_t other_path_offset = offsets;
-               for(int i=0; i<3; i++) {
-                  other_path_offset[i] -= cells_seen[i];
-               }
+					// The remaining path to walk is shorter.
+					Types<3>::neighborhood_item_t other_path_offset = offsets;
+					for(int i=0; i<3; i++) {
+						other_path_offset[i] -= cells_seen[i];
+					}
 
-               Types<3>::indices_t other_path_x = {(uint64_t)x[0], (uint64_t)x[1], (uint64_t)x[2]};
+					Types<3>::indices_t other_path_x = {(uint64_t)x[0], (uint64_t)x[1], (uint64_t)x[2]};
 
-               // TODO: This can be optimized in the corners.
-               // Find at offset (1,0)
-               other_path_x[dim1] += sign(offsets[dim1])* (1<<(this->mapping.get_maximum_refinement_level() - (refinement_level+1)));
-               retval.merge(find_cells_at_offset(other_path_x, last_cell_seen, refinement_level+1, other_path_offset, dims));
-               // Find at offset (1,1)
-               other_path_x[dim2] += sign(offsets[dim2])* (1<<(this->mapping.get_maximum_refinement_level() - (refinement_level+1)));
-               retval.merge(find_cells_at_offset(other_path_x, last_cell_seen, refinement_level+1, other_path_offset, dims));
-               // Find at offset (0,1)
-               other_path_x[dim1] = x[dim1];
-               retval.merge(find_cells_at_offset(other_path_x, last_cell_seen, refinement_level+1, other_path_offset, dims));
-               // The fourth path will continue here as before.
-            }
-         }
-      }
+					// TODO: This can be optimized in the corners.
+					// Find at offset (1,0)
+					other_path_x[dim1] += sign(offsets[dim1])* (1<<(this->mapping.get_maximum_refinement_level() - (refinement_level+1)));
+					retval.merge(find_cells_at_offset(other_path_x, last_cell_seen, refinement_level+1, other_path_offset, dims));
+					// Find at offset (1,1)
+					other_path_x[dim2] += sign(offsets[dim2])* (1<<(this->mapping.get_maximum_refinement_level() - (refinement_level+1)));
+					retval.merge(find_cells_at_offset(other_path_x, last_cell_seen, refinement_level+1, other_path_offset, dims));
+					// Find at offset (0,1)
+					other_path_x[dim1] = x[dim1];
+					retval.merge(find_cells_at_offset(other_path_x, last_cell_seen, refinement_level+1, other_path_offset, dims));
+					// The fourth path will continue here as before.
+				}
+			}
+		}
 
-       // The last cell we encountered must be our neighbour.
-       retval.emplace(last_cell_seen);
+		// The last cell we encountered must be our neighbour.
+		retval.emplace(last_cell_seen);
 
-       return retval;
-   }
+		return retval;
+	}
 
 	/*!
 	Returns the indices corresponding to the given neighborhood at given indices.
@@ -4884,11 +4884,13 @@ public:
 		#endif
 
 		// Iterate through the neighborhood
-		for (const auto& offsets: neighborhood) {
+		// Note that for neighbors_to calculations, these are already
+		// inverted from the "proper" neighborhoods
+		for (const auto& inverse_offsets: neighborhood) {
 
 			// Find the neighbour(s) in opposite direction
-			Types<3>::neighborhood_item_t inverse_offsets = {-offsets[0], -offsets[1], -offsets[2]};
-			std::set<uint64_t> neigh_cells = this->find_cells_at_offset(this->mapping.get_indices(cell),cell, refinement_level, offsets, {1,0,2});
+			Types<3>::neighborhood_item_t offsets = {-inverse_offsets[0], -inverse_offsets[1], -inverse_offsets[2]};
+			std::set<uint64_t> neigh_cells = this->find_cells_at_offset(this->mapping.get_indices(cell),cell, refinement_level, inverse_offsets, {1,0,2});
 
 			for (const auto& neighCell : neigh_cells) {
 				if (neighCell == error_cell) {
@@ -4901,9 +4903,9 @@ public:
 				return_neighbors.push_back({
 						neighCell,
 						{
-							inverse_offsets[0],
-							inverse_offsets[1],
-							inverse_offsets[2],
+							offsets[0],
+							offsets[1],
+							offsets[2],
 							// NOTE: For whatever reason, return value is negative here if refinement mismatches
 							[&](){
 								if(neighbor_ref_lvl == refinement_level) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -772,7 +772,8 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_data.count(cell) > 0) {
+		//if (this->cell_data.count(cell) > 0) {
+		if (this->cell_process.count(cell) > 0) {
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
 				if (this->neighbors_of.count(cell) == 0) {
@@ -826,7 +827,8 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_data.count(cell) > 0) {
+		//if (this->cell_data.count(cell) > 0) {
+		if (this->cell_process.count(cell) > 0) {
 
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
@@ -2644,9 +2646,10 @@ public:
 	) const {
 		std::vector<std::pair<uint64_t, int> > ret_val;
 
-		if (this->cell_data.count(cell) == 0) {
-			return ret_val;
-		}
+		// Allow face neighbour searches for non-local cells
+		// if (this->cell_data.count(cell) == 0) {
+		// 	return ret_val;
+		// }
 
 
 		// Iterate through neighbours and only return those with a single 1
@@ -2828,6 +2831,7 @@ public:
 			return ret_val;
 		}
 
+		// TODO: Comment out? MCB 1.7.2024
 		if (this->cell_process.at(cell) != this->rank) {
 			return ret_val;
 		}
@@ -2880,6 +2884,7 @@ public:
 			return ret_val;
 		}
 
+		// TODO: Comment out? MCB 1.7.2024
 		if (this->cell_process.at(cell) != this->rank) {
 			return ret_val;
 		}
@@ -8697,9 +8702,9 @@ private:
 			return;
 		}
 
-		if (this->cell_process.at(cell) != this->rank) {
-			return;
-		}
+		// if (this->cell_process.at(cell) != this->rank) {
+		// 	return;
+		// }
 
 		if (cell != this->get_child(cell)) {
 			return;
@@ -8711,7 +8716,6 @@ private:
 			found_neighbors_of.push_back(i.first);
 		}
 		this->neighbors_to[cell] = this->find_neighbors_to(cell, this->neighborhood_to);
-
 		#ifdef DEBUG
 		if (
 			!this->verify_neighbors(
@@ -10280,7 +10284,24 @@ private:
 	}
 
 public:
-	/*!
+	void force_update_cell_neighborhoods(const std::vector<uint64_t> cells)
+	{
+		for (uint i=0; i<cells.size(); i++) {
+			this->update_neighbors(cells[i]);
+		}
+		// also remote neighbor data of user neighborhoods
+		for (std::unordered_map<int, std::vector<Types<3>::neighborhood_item_t>>::const_iterator
+			item = this->user_hood_of.begin();
+			item != this->user_hood_of.end();
+			item++
+		) {
+			for (uint i=0; i<cells.size(); i++) {
+				this->update_user_neighbors(cells[i],item->first);
+			}
+		}
+	}
+
+        /*!
 	Returns the smallest existing cell at given indices between given refinement levels inclusive.
 
 	Returns error_cell if no cell between given refinement ranges exists or an index is outside of

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8377,7 +8377,7 @@ private:
 
 			const int current_process = int(this->rank);
 
-			// data must be received from neighbors_of
+			// data must be sent/received to/from neighbors_of
 			for (const auto& neighbor_i: this->neighbors_of.at(cell)) {
 				const auto& neighbor = neighbor_i.first;
 
@@ -8389,10 +8389,11 @@ private:
 
 				if (other_process != current_process) {
 					unique_cells_to_receive[other_process].insert(neighbor);
+					unique_cells_to_send[other_process].insert(cell);
 				}
 			}
 
-			// data must be sent to neighbors_to
+			// data must be sent/received to/from neighbors_to
 			for (const auto& neighbor_i: this->neighbors_to.at(cell)) {
 				const auto& neighbor = neighbor_i.first;
 
@@ -8403,6 +8404,7 @@ private:
 				const int other_process = int(this->cell_process.at(neighbor));
 
 				if (other_process != current_process) {
+					unique_cells_to_receive[other_process].insert(neighbor);
 					unique_cells_to_send[other_process].insert(cell);
 				}
 			}

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -220,6 +220,10 @@ private:
 	*/
 	Grid_Topology topology_rw;
 
+	static constexpr std::array<std::array<int,3>,6> dim_permutations = {{
+		{0,1,2}, {0,2,1}, {1,0,2}, {1,2,0}, {2,0,1}, {2,1,0}
+	}};
+
 public:
 	/*!
 	Public read-only version of the grid's topology.
@@ -4903,10 +4907,9 @@ public:
 
 			// Find the neighbour(s) there
 			std::set<uint64_t> neigh_cells;
-			std::array<int,3> dims({0,1,2});
-			do {
+			for(const auto& dims : dim_permutations) {
 				neigh_cells.merge(this->find_cells_at_offset(this->mapping.get_indices(cell), cell, refinement_level, offsets, dims));
-			} while(std::next_permutation(dims.begin(),dims.end()));
+			}
 
 			for (const auto& neighCell : neigh_cells) {
 				if (neighCell == error_cell) {
@@ -5003,10 +5006,9 @@ public:
 			// Find the neighbour(s) in opposite direction
 			Types<3>::neighborhood_item_t offsets = {-inverse_offsets[0], -inverse_offsets[1], -inverse_offsets[2]};
 			std::set<uint64_t> neigh_cells;
-			std::array<int,3> dims({0,1,2});
-			do {
+			for(const auto& dims : dim_permutations) {
 				neigh_cells.merge(this->find_cells_at_offset(this->mapping.get_indices(cell),cell, refinement_level, inverse_offsets, dims));
-			} while(std::next_permutation(dims.begin(),dims.end()));
+			}
 
 			for (const auto& neighCell : neigh_cells) {
 				if (neighCell == error_cell) {
@@ -9108,8 +9110,7 @@ private:
 					}
 
 					// Look in neighbors_of
-					std::array<int,3> dims({0,1,2});
-					do {
+					for(const auto& dims : dim_permutations) {
 						std::set<uint64_t> neighborsHere = find_cells_at_offset(indices1, cell1, refinement_level, {x,y,z}, dims);
 						if(neighborsHere.count(cell2) > 0) {
 							return true;
@@ -9120,7 +9121,7 @@ private:
 						if(neighborsHere.count(cell2) > 0) {
 							return true;
 						}
-					} while(std::next_permutation(dims.begin(),dims.end()));
+					}
 				}
 			}
 		}
@@ -9209,13 +9210,12 @@ private:
 									Types<3>::neighborhood_item_t offsets({x,y,z});
 									Types<3>::indices_t indices = this->mapping.get_indices(refined);
 
-									std::array<int,3> dims({0,1,2});
-									do {
+									for(const auto& dims : dim_permutations) {
 										to_be_induced.merge(find_speculative_induced_refines(indices,refined,
 													this->mapping.get_refinement_level(refined)+1,
 													all_new_refines.at(this->rank),
 													offsets, dims));
-									} while(std::next_permutation(dims.begin(),dims.end()));
+									}
 								}
 							}
 						}

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4538,7 +4538,11 @@ public:
 						// The remaining path to walk is shorter.
 						Types<3>::neighborhood_item_t other_path_offset = offsets;
 						for(int i=0; i<3; i++) {
-							other_path_offset[i] -= cells_seen[i];
+							if(other_path_offset[i] > 0) {
+								other_path_offset[i] -= cells_seen[i];
+							} else {
+								other_path_offset[i] += cells_seen[i];
+							}
 						}
 
 						Types<3>::indices_t other_path_x = {(uint64_t)x[0], (uint64_t)x[1], (uint64_t)x[2]};

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4462,7 +4462,10 @@ public:
 					steps_inside_this_cell = 0;
 
 					// If this cell had a higher refinement, we need to continue multiple paths.
-					if(this->mapping.get_refinement_level(cellHere) > refinement_level) {
+					if(this->mapping.get_refinement_level(cellHere) > this->mapping.get_refinement_level(last_cell_seen)) {
+
+						int prev_refinement_level = this->mapping.get_refinement_level(last_cell_seen);
+						int new_refinement_level = this->mapping.get_refinement_level(cellHere);
 
 						// We select two dimensions perpendicular to our current walking direction
 						// and splitting the path among them.
@@ -4481,26 +4484,26 @@ public:
 
 						// The other paths start such that they are quantized to the refinement level edges
 						for(int i : {dim1,dim2}) {
-							x[i] -= x[i] % (1<<(this->mapping.get_maximum_refinement_level() - refinement_level));
+							x[i] -= x[i] % (1<<(this->mapping.get_maximum_refinement_level() - prev_refinement_level));
 						}
 						Types<3>::indices_t other_path_x = {(uint64_t)x[0], (uint64_t)x[1], (uint64_t)x[2]};
 
 						// Find at offset (1,0)
-						other_path_x[dim1] += (1<<(this->mapping.get_maximum_refinement_level() - (refinement_level+1)));
-						uint64_t otherCellHere = this->get_existing_cell(other_path_x, refinement_level+1, refinement_level+1);
-						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, refinement_level+1, other_path_offset, dims));
+						other_path_x[dim1] += (1<<(this->mapping.get_maximum_refinement_level() - new_refinement_level));
+						uint64_t otherCellHere = this->get_existing_cell(other_path_x, new_refinement_level, new_refinement_level);
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims, debug+1));
 						// Find at offset (1,1)
-						other_path_x[dim2] += (1<<(this->mapping.get_maximum_refinement_level() - (refinement_level+1)));
-						otherCellHere = this->get_existing_cell(other_path_x, refinement_level+1, refinement_level+1);
-						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, refinement_level+1, other_path_offset, dims));
+						other_path_x[dim2] += (1<<(this->mapping.get_maximum_refinement_level() - new_refinement_level));
+						otherCellHere = this->get_existing_cell(other_path_x, new_refinement_level, new_refinement_level);
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims, debug+1));
 						// Find at offset (0,1)
 						other_path_x[dim1] = x[dim1];
-						otherCellHere = this->get_existing_cell(other_path_x, refinement_level+1, refinement_level+1);
-						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, refinement_level+1, other_path_offset, dims));
+						otherCellHere = this->get_existing_cell(other_path_x, new_refinement_level, new_refinement_level);
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, refinement_level+1, other_path_offset, dims, debug+1));
 						// The fourth path will continue here as before.
 						other_path_x[dim2] = x[dim2];
-						otherCellHere = this->get_existing_cell(other_path_x, refinement_level+1, refinement_level+1);
-						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, refinement_level+1, other_path_offset, dims));
+						otherCellHere = this->get_existing_cell(other_path_x, new_refinement_level, new_refinement_level);
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims, debug+1));
 						return retval;
 					}
 

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8794,10 +8794,6 @@ private:
 		}
 
 		this->neighbors_of[cell] = this->find_neighbors_of(cell, this->neighborhood_of, this->max_ref_lvl_diff);
-		std::vector<uint64_t> found_neighbors_of;
-		for (const auto& i: this->neighbors_of[cell]) {
-			found_neighbors_of.push_back(i.first);
-		}
 		this->neighbors_to[cell] = this->find_neighbors_to(cell, this->neighborhood_to);
 		#ifdef DEBUG
 		if (
@@ -8832,6 +8828,8 @@ private:
 			}
 		}
 		#endif
+		// Update also cached face neighbors
+		this->face_neighbors_of[cell] = this->find_face_neighbors_of(cell);
 	}
 
 

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4491,19 +4491,19 @@ public:
 						// Find at offset (1,0)
 						other_path_x[dim1] += (1<<(this->mapping.get_maximum_refinement_level() - new_refinement_level));
 						uint64_t otherCellHere = this->get_existing_cell(other_path_x, new_refinement_level, new_refinement_level);
-						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims, debug+1));
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims));
 						// Find at offset (1,1)
 						other_path_x[dim2] += (1<<(this->mapping.get_maximum_refinement_level() - new_refinement_level));
 						otherCellHere = this->get_existing_cell(other_path_x, new_refinement_level, new_refinement_level);
-						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims, debug+1));
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims));
 						// Find at offset (0,1)
 						other_path_x[dim1] = x[dim1];
 						otherCellHere = this->get_existing_cell(other_path_x, new_refinement_level, new_refinement_level);
-						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims, debug+1));
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims));
 						// The fourth path will continue here as before.
 						other_path_x[dim2] = x[dim2];
 						otherCellHere = this->get_existing_cell(other_path_x, new_refinement_level, new_refinement_level);
-						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims, debug+1));
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, new_refinement_level, other_path_offset, dims));
 						return retval;
 					}
 

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4485,15 +4485,21 @@ public:
 
 						// Find at offset (1,0)
 						other_path_x[dim1] += (1<<(this->mapping.get_maximum_refinement_level() - (refinement_level+1)));
-						retval.merge(find_cells_at_offset(other_path_x, last_cell_seen, refinement_level+1, other_path_offset, dims));
+						uint64_t otherCellHere = this->get_existing_cell(other_path_x, refinement_level+1, refinement_level+1);
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, refinement_level+1, other_path_offset, dims));
 						// Find at offset (1,1)
 						other_path_x[dim2] += (1<<(this->mapping.get_maximum_refinement_level() - (refinement_level+1)));
-						retval.merge(find_cells_at_offset(other_path_x, last_cell_seen, refinement_level+1, other_path_offset, dims));
+						otherCellHere = this->get_existing_cell(other_path_x, refinement_level+1, refinement_level+1);
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, refinement_level+1, other_path_offset, dims));
 						// Find at offset (0,1)
 						other_path_x[dim1] = x[dim1];
-						retval.merge(find_cells_at_offset(other_path_x, last_cell_seen, refinement_level+1, other_path_offset, dims));
+						otherCellHere = this->get_existing_cell(other_path_x, refinement_level+1, refinement_level+1);
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, refinement_level+1, other_path_offset, dims));
 						// The fourth path will continue here as before.
-						refinement_level++;
+						other_path_x[dim2] = x[dim2];
+						otherCellHere = this->get_existing_cell(other_path_x, refinement_level+1, refinement_level+1);
+						retval.merge(find_cells_at_offset(other_path_x, otherCellHere, refinement_level+1, other_path_offset, dims));
+						return retval;
 					}
 
 				} else {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -9330,7 +9330,7 @@ private:
 		std::vector<std::vector<uint64_t>> all_unrefines;
 		All_Gather()(unrefines, all_unrefines, this->comm);
 
-		for (unsigned int process = 0; process < this->comm_size; process++) {
+		for (unsigned int process = 0; process < all_unrefines.size(); process++) {
 			this->cells_to_unrefine.insert(
 				all_unrefines[process].begin(),
 				all_unrefines[process].end()

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4373,9 +4373,10 @@ public:
 
 		this->allocate_copies_of_remote_neighbors();
 		this->update_cell_pointers();
-		for (const auto& item: this->user_hood_of) {
-			this->allocate_copies_of_remote_neighbors(item.first);
-		}
+		// All remote neighbors of user hoods are already included in base hood
+		// for (const auto& item: this->user_hood_of) {
+		//	this->allocate_copies_of_remote_neighbors(item.first);
+		// }
 
 		#ifdef DEBUG
 		if (!this->is_consistent()) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -772,7 +772,7 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_process.count(cell) > 0) {
+		if (this->cell_data.count(cell) > 0) {
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
 				if (this->neighbors_of.count(cell) == 0) {
@@ -826,7 +826,7 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		if (this->cell_process.count(cell) > 0) {
+		if (this->cell_data.count(cell) > 0) {
 
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
@@ -2644,7 +2644,7 @@ public:
 	) const {
 		std::vector<std::pair<uint64_t, int> > ret_val;
 
-		if (this->cell_process.count(cell) == 0) {
+		if (this->cell_data.count(cell) == 0) {
 			return ret_val;
 		}
 
@@ -8775,7 +8775,7 @@ private:
 		}
 		#endif
 
-		if (this->cell_process.count(cell) == 0) {
+		if (this->cell_data.count(cell) == 0) {
 			return;
 		}
 		this->user_neigh_of[neighborhood_id][cell].clear();

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -772,7 +772,6 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		//if (this->cell_data.count(cell) > 0) {
 		if (this->cell_process.count(cell) > 0) {
 			if (neighborhood_id == default_neighborhood_id) {
 				#ifdef DEBUG
@@ -827,7 +826,6 @@ public:
 		const uint64_t cell,
 		const int neighborhood_id = default_neighborhood_id
 	) const {
-		//if (this->cell_data.count(cell) > 0) {
 		if (this->cell_process.count(cell) > 0) {
 
 			if (neighborhood_id == default_neighborhood_id) {
@@ -2646,11 +2644,9 @@ public:
 	) const {
 		std::vector<std::pair<uint64_t, int> > ret_val;
 
-		// Allow face neighbour searches for non-local cells
-		// if (this->cell_data.count(cell) == 0) {
-		// 	return ret_val;
-		// }
-
+		if (this->cell_process.count(cell) > 0) {
+			return ret_val;
+		}
 
 		// Iterate through neighbours and only return those with a single 1
 		// index.
@@ -2831,7 +2827,6 @@ public:
 			return ret_val;
 		}
 
-		// TODO: Comment out? MCB 1.7.2024
 		if (this->cell_process.at(cell) != this->rank) {
 			return ret_val;
 		}
@@ -2884,7 +2879,6 @@ public:
 			return ret_val;
 		}
 
-		// TODO: Comment out? MCB 1.7.2024
 		if (this->cell_process.at(cell) != this->rank) {
 			return ret_val;
 		}
@@ -8702,6 +8696,7 @@ private:
 			return;
 		}
 
+		// Allow neighbors of remote cells to be evaluated
 		// if (this->cell_process.at(cell) != this->rank) {
 		// 	return;
 		// }

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4545,7 +4545,7 @@ public:
 
 						// The other paths start such that they are quantized to the refinement level edges
 						Types<3>::indices_t other_path_x = {(uint64_t)x[0], (uint64_t)x[1], (uint64_t)x[2]};
-						for(int i=0; i<3; i++) {
+						for(int i : {dim1,dim2}) {
 							x[i] -= x[i] % (1<<(this->mapping.get_maximum_refinement_level() - refinement_level));
 						}
 

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -9500,11 +9500,12 @@ private:
 			this->all_to_all_set(new_donts);
 		} while (new_donts.size() > 0);
 
-		for (const auto& cell : old_donts) {
-			if(!this->is_local(cell)) {
-				old_donts.erase(cell);
-			}
-		}
+		std::erase_if(old_donts, [this](uint64_t cell)->bool{return !this->is_local(cell);});;
+		//for (const auto& cell : old_donts) {
+		//	if(!this->is_local(cell)) {
+		//		old_donts.erase(cell);
+		//	}
+		//}
 
 		this->cells_not_to_refine = old_donts;
 		this->all_to_all_set(this->cells_not_to_refine);

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -8998,12 +8998,11 @@ private:
 								// Count how many unique cells were encountered.
 								cells_seen[dimension]++;
 							}
-
-							if(cells_seen[dimension] > (int)this->neighborhood_length) {
-								goto next_path;
-							}
-
 							last_cell_seen = cellHere;
+
+							if(cells_seen[dimension] >= (int)this->neighborhood_length) {
+								break;
+							}
 
 							if(steps[dimension] == 0) {
 								break;

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4888,7 +4888,7 @@ public:
 
 			// Find the neighbour(s) in opposite direction
 			Types<3>::neighborhood_item_t inverse_offsets = {-offsets[0], -offsets[1], -offsets[2]};
-			std::set<uint64_t> neigh_cells = this->find_cells_at_offset(this->mapping.get_indices(cell),cell, refinement_level, inverse_offsets, {1,0,2});
+			std::set<uint64_t> neigh_cells = this->find_cells_at_offset(this->mapping.get_indices(cell),cell, refinement_level, offsets, {1,0,2});
 
 			for (const auto& neighCell : neigh_cells) {
 				if (neighCell == error_cell) {

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -7490,7 +7490,7 @@ private:
 		int worker_procs = this->comm_size;
 		if(getenv("DCCRG_PROCS") != NULL) {
 			const int dccrg_procs = atoi(getenv("DCCRG_PROCS"));
-			if(dccrg_procs > 0 && dccrg_procs < this->comm_size)
+			if(dccrg_procs > 0 && (uint)dccrg_procs < this->comm_size)
 				worker_procs = dccrg_procs;
 		}
 		const int zoltan_worker = (this->rank < this->comm_size - worker_procs) ? 0 : 1;

--- a/dccrg_mpi_support.hpp
+++ b/dccrg_mpi_support.hpp
@@ -185,6 +185,10 @@ public:
 			total_send_count += (uint64_t) send_count;
 		}
 
+		if(total_send_count == 0) {
+			//Early abort if there is nothing to communicate.
+			return;
+		}
 		std::vector<uint64_t> temp_result(total_send_count, std::numeric_limits<uint64_t>::max());
 
 		// give a sane address to gatherv also when nothing to send

--- a/dccrg_mpi_support.hpp
+++ b/dccrg_mpi_support.hpp
@@ -117,6 +117,8 @@ public:
 		}
 
 		std::vector<int> send_counts(comm_size, -1);
+		result.clear();
+		result.resize(comm_size);
 
 		// TODO: make send_count uint64_t when they can be given to MPI_Allgatherv
 		int send_count = 0;
@@ -218,8 +220,6 @@ public:
 		}
 
 		// fill result
-		result.clear();
-		result.resize(comm_size);
 		for (size_t i = 0; i < (size_t) comm_size; i++) {
 			result[i].resize(send_counts[i]);
 		}


### PR DESCRIPTION
This PR changes the fundamental definition of what a "neighbor" is.
So far, in DCCRG, neighbor locations were always specified in units of the origin cell's size. At refinement level interfaces, this sometimes caused unintuitive behaviour, such as the same cell being addressed with different indices, or more cells than necessary being returned. In Vlasiator, this required some extensive workarounds, and a larger communication halo size (n=3) than would otherwise be required by the solvers (n=2).

With this PR, the definition of a neighbor at offset (x,y,z) is changed to mean "a cell that is encountered when walking along the highest refinement level, as the z-th unique cell in dimension 2, x-th cell in dimension 0 and y-th cell in dimension 1".  This nontrivial dimension ordering, of course, stems from the internal use of vlasiator's translation solver.

This obviates most of the workarounds in the Vlasiator codebase, but probably breaks general-purpose usage of DCCRG, hence this PR is targeted towards the vlasiator-version branch. As a prototype implementation, no care has been taken to retain the previous structure, and a thorough refactoring would be required if both are to be used side-by-side.

This has been verified with Vlasiator global Magnetospheric runs.