### PR TITLE
Free communicator

### DIFF
--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -503,6 +503,16 @@ public:
 		return *this;
 	}
 
+	void finalize() {
+		if (mpi_comm != MPI_COMM_NULL) {
+			MPI_Comm_free(&mpi_comm);
+			mpi_comm = MPI_COMM_NULL;
+		}
+	}
+
+	~Dccrg() {
+		finalize();
+	}
 
 	/*!
 	Sets the geometry of the grid to given values.


### PR DESCRIPTION
Implement function `finalize()` to free `mpi_comm` and a destructor which calls it.