### PR TITLE
Correct typing for MPI processes

### DIFF
--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -340,8 +340,8 @@ public:
 		max_tag(other.get_max_tag()),
 		send_single_cells(other.get_send_single_cells()),
 		comm(other.get_communicator()),
-		rank((other.get_rank())),
-		comm_size((other.get_comm_size())),
+		rank(other.get_rank()),
+		comm_size(other.get_comm_size()),
 		neighborhood_of(other.get_neighborhood_of()),
 		neighborhood_to(other.get_neighborhood_to()),
 		user_hood_of(other.get_user_hood_of()),
@@ -7300,7 +7300,7 @@ private:
 	// the grid is distributed between these processes
 	MPI_Comm comm;
 	int rank;
-   int comm_size;
+	int comm_size;
 
 	// cells and their data on this process
 	std::unordered_map<uint64_t, Cell_Data> cell_data;

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -3636,8 +3636,8 @@ public:
 			// TODO: merge with identical code in make_new_partition
 			for (size_t i = 0; i < cell_pairs.size(); i++) {
 
-				const int tag = static_cast<int>(i) + 1;
-				if (tag > this->max_tag) {
+				const size_t tag = i + 1;
+				if (tag > static_cast<size_t>(this->max_tag)) {
 					std::cerr << __FILE__ << ":" << __LINE__
 						<< " Process " << this->rank
 						<< ": Message tag would overflow for receiving cell " << cell_pairs[i].first
@@ -3646,7 +3646,7 @@ public:
 					abort();
 				}
 
-				cell_pairs[i].second = tag;
+				cell_pairs[i].second = static_cast<int>(tag);
 			}
 		}
 
@@ -3656,8 +3656,8 @@ public:
 			// TODO: check that message tags don't overflow
 			for (size_t i = 0; i < cell_pairs.size(); i++) {
 
-				const int tag = static_cast<int>(i) + 1;
-				if (tag > this->max_tag) {
+				const size_t tag = i + 1;
+				if (tag > static_cast<size_t>(this->max_tag)) {
 					std::cerr << __FILE__ << ":" << __LINE__
 						<< " Process " << this->rank
 						<< ": Message tag would overflow for sending cell " << cell_pairs[i].first
@@ -3666,7 +3666,7 @@ public:
 					abort();
 				}
 
-				cell_pairs[i].second = tag;
+				cell_pairs[i].second = static_cast<int>(tag);
 			}
 		}
 
@@ -8521,8 +8521,8 @@ private:
 			std::sort(cell_pairs.begin(), cell_pairs.end());
 
 			for (size_t i = 0; i < cell_pairs.size(); i++) {
-				const int tag = static_cast<int>(i) + 1;
-				if (tag > this->max_tag) {
+				const size_t tag = i + 1;
+				if (tag > static_cast<size_t>(this->max_tag)) {
 					std::cerr << __FILE__ << ":" << __LINE__
 						<< " Process " << this->rank
 						<< ": Message tag would overflow for receiving cell " << cell_pairs[i].first
@@ -8530,7 +8530,7 @@ private:
 						<< std::endl;
 					abort();
 				}
-				cell_pairs[i].second = tag;
+				cell_pairs[i].second = static_cast<int>(tag);
 			}
 		}
 

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -7677,37 +7677,33 @@ private:
 			return false;
 		}
 
-		int temp_size = 0;
-		ret_val = MPI_Comm_size(this->comm, &temp_size);
+		ret_val = MPI_Comm_size(this->comm, &this->comm_size);
 		if (ret_val != MPI_SUCCESS) {
 			std::cerr << __FILE__ << ":" << __LINE__
 				<< " Couldn't get size of communicator: " << Error_String()(ret_val)
 				<< std::endl;
 			return false;
 		}
-		if (temp_size < 0) {
+		if (this->comm_size < 0) {
 			std::cerr << __FILE__ << ":" << __LINE__
-				<< " Negative MPI comm size not supported: " << temp_size
+				<< " Negative MPI comm size not supported: " << this->comm_size
 				<< std::endl;
 			return false;
 		}
-		this->comm_size = temp_size;
 
-		int temp_rank = 0;
-		ret_val = MPI_Comm_rank(this->comm, &temp_rank);
+		ret_val = MPI_Comm_rank(this->comm, &this->rank);
 		if (ret_val != MPI_SUCCESS) {
 			std::cerr << __FILE__ << ":" << __LINE__
 				<< " Couldn't get rank for communicator: " << Error_String()(ret_val)
 				<< std::endl;
 			return false;
 		}
-		if (temp_rank < 0) {
+		if (this->rank < 0) {
 			std::cerr << __FILE__ << ":" << __LINE__
-				<< " Negative MPI rank not supported: " << temp_rank
+				<< " Negative MPI rank not supported: " << this->rank
 				<< std::endl;
 			abort();
 		}
-		this->rank = temp_rank;
 
 		// get maximum tag value
 		int attr_flag = -1, *attr = NULL;


### PR DESCRIPTION
Make all MPI process variables (e.g. rank, size) into signed integers as that's what they are in MPI. Also replaces iterators with range-based loops with unpacked variables.