### PR TITLE
Support non-finest cell as neighborhood search starting points

### DIFF
--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4382,17 +4382,20 @@ public:
 
 			while(cells_seen[dimension] <= abs(offsets[dimension]) && last_cell_seen != error_cell) {
 
-				uint64_t cellHere = this->get_existing_cell(
-						{(uint64_t)x[0],(uint64_t)x[1],(uint64_t)x[2]},
-						std::max(refinement_level-1,0), 
-						std::min(refinement_level+1, this->mapping.get_maximum_refinement_level()));
+				uint64_t cellHere;
+
 				// Check whether we are still inside the starting cell (which
 				// *might* not be the smallest in this location, if we are looking
 				// for speculative neighbors for unrefining.)
-				int cell_at_location = this->mapping.get_cell_from_indices({(uint64_t)x[0],(uint64_t)x[1],(uint64_t)x[2]}, refinement_level);
+				uint64_t cell_at_location = this->mapping.get_cell_from_indices({(uint64_t)x[0],(uint64_t)x[1],(uint64_t)x[2]}, refinement_level);
 				if(cell_at_location == starting_cell) {
 					// Yup, we are.
 					cellHere = starting_cell;
+				} else {
+					cellHere = this->get_existing_cell(
+						{(uint64_t)x[0],(uint64_t)x[1],(uint64_t)x[2]},
+						std::max(refinement_level-1,0), 
+						std::min(refinement_level+1, this->mapping.get_maximum_refinement_level()));
 				}
 
 				// Apparently, this is a new cell.

--- a/dccrg.hpp
+++ b/dccrg.hpp
@@ -4386,6 +4386,14 @@ public:
 						{(uint64_t)x[0],(uint64_t)x[1],(uint64_t)x[2]},
 						std::max(refinement_level-1,0), 
 						std::min(refinement_level+1, this->mapping.get_maximum_refinement_level()));
+				// Check whether we are still inside the starting cell (which
+				// *might* not be the smallest in this location, if we are looking
+				// for speculative neighbors for unrefining.)
+				int cell_at_location = this->mapping.get_cell_from_indices({(uint64_t)x[0],(uint64_t)x[1],(uint64_t)x[2]}, refinement_level);
+				if(cell_at_location == starting_cell) {
+					// Yup, we are.
+					cellHere = starting_cell;
+				}
 
 				// Apparently, this is a new cell.
 				if(cellHere != last_cell_seen) {


### PR DESCRIPTION
When unrefining, DCCRG tries to speculatively find the neighbors of the new parent cell (if it existed), to see whether refinement level constrains prevent it. But the neighbor-finding algorithm always ran on the "how it actually is right now" state, so it misidentified those neighbors.

The fix is to let the neighbor finding algorithm cheat itself a little bit, by running with a ficticuous initial cell.